### PR TITLE
Update README with backend instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # trmnl-builder
-📘 Siehe `docs/TRMNL_GUIDELINE.md` für alle Design- und Hardwareregeln.
+
+Dieses Repository enthält eine Express.js-Anwendung zum Exportieren von TRMNL Templates.
+
+📘 Siehe [TRMNL_GUIDELINE.md](TRMNL_GUIDELINE.md) für alle Design- und Hardwareregeln.
+
+## Backend starten
+
+```bash
+cd backend
+npm install
+npm start
+```


### PR DESCRIPTION
## Summary
- update README to fix guideline link
- add instructions for running the backend

## Testing
- `npm test` in `backend` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_6841cacaede0832a8e7e3e79cf20fbd6