### PR TITLE
Update backend port and frontend env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   backend:
     build: ./backend
     ports:
-      - "5000:5000"
+      - "5001:5000"
     volumes:
       - ./backend:/app
     env_file:

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:5001


### PR DESCRIPTION
## Summary
- expose backend on host port 5001
- set frontend base URL to use new port

## Testing
- `npm test` in backend (fails: Error: no test specified)
- `npm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_68429e7dd96c832ab5ebde9a70fecbd7