### PR TITLE
Update Dockerfiles and ignore node_modules

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:18
 WORKDIR /app
+
+# Nur package.json und lockfile kopieren und installieren
 COPY package*.json ./
 RUN npm install
+
+# Restliche Dateien kopieren, node_modules dabei ignorieren (siehe .dockerignore)
 COPY . .
-EXPOSE 5000
+
+EXPOSE 5001
 CMD ["npm", "run", "start"]

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:18
 WORKDIR /app
+
+# Nur package.json und lockfile kopieren und installieren
 COPY package*.json ./
 RUN npm install
+
+# Restliche Dateien kopieren, node_modules dabei ignorieren (siehe .dockerignore)
 COPY . .
+
 EXPOSE 3000
 CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Summary
- adjust Dockerfiles for backend and frontend to install deps before copy
- expose backend on port 5001
- add `.dockerignore` files to exclude `node_modules`

## Testing
- `npm test` in `backend` *(fails: no tests specified)*
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6842b8815eb4832abcacf21a1329b395