### PR TITLE
Add dev/prod docker-compose setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,17 @@ docker-compose up
 
 ✅ Compose optimiert nach Best Practices
 
+
+## Docker Compose: Dev vs. Prod
+
+### Entwicklung
+
+```bash
+docker-compose -f docker-compose.dev.yml up --build
+```
+
+### Produktion
+
+```bash
+docker-compose -f docker-compose.prod.yml up --build -d
+```

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,42 @@
+version: '3.9'
+services:
+  backend:
+    build:
+      context: ./backend
+    ports:
+      - "5002:5000"
+    volumes:
+      - ./backend:/app
+    env_file:
+      - ./backend/.env
+    environment:
+      NODE_ENV: development
+      PORT: 5000
+    command: npm start
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  frontend:
+    build:
+      context: ./frontend
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+    env_file:
+      - ./frontend/.env
+    environment:
+      NODE_ENV: development
+    depends_on:
+      - backend
+    command: npm run dev -- --host
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,31 @@
+version: '3.9'
+services:
+  backend:
+    build:
+      context: ./backend
+    expose:
+      - "5000"
+    environment:
+      NODE_ENV: production
+      PORT: 5000
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.prod
+    ports:
+      - "80:80"
+    depends_on:
+      - backend
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,0 +1,12 @@
+FROM node:18 AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name _;
+
+    location /api/ {
+        proxy_pass http://backend:5000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+        root /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
## Summary
- create dedicated docker-compose files for development and production
- add production Dockerfile with nginx reverse proxy
- provide example nginx.conf
- document how to start both setups

## Testing
- `docker compose -f docker-compose.dev.yml config` *(fails: `docker: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_6842d9fac824832a88ee2fe924cae42b