### PR TITLE
Add production frontend Dockerfile and compose service

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ docker-compose up
 
 Backend erreichbar unter http://localhost:5002, Frontend unter http://localhost:3000.
 
+### Beispiele
+
+**Entwicklung**
+
+```bash
+docker-compose up frontend backend
+```
+
+**Produktion**
+
+```bash
+docker-compose up frontend-prod backend
+```
+
 ## Lokale Ports
 
 - Frontend: http://localhost:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,3 +40,18 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+  frontend-prod:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.prod
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,11 +1,11 @@
-FROM node:18 AS builder
+FROM node:18-alpine AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM nginx:alpine
+FROM nginx:stable-alpine
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 EXPOSE 80


### PR DESCRIPTION
## Summary
- update frontend production Dockerfile to use alpine images
- add `frontend-prod` service to docker-compose
- document dev and prod compose commands

## Testing
- `npm --version`
- `npm run build` *(fails: vite not found)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f6a9b4ac832a98b063ed80257346