### PR TITLE
Add backend production build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ docker-compose up frontend backend
 **Produktion**
 
 ```bash
-docker-compose up frontend-prod backend
+docker-compose up frontend-prod backend-prod
 ```
 
 ## Lokale Ports

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,0 +1,12 @@
+FROM node:18-alpine
+WORKDIR /app
+
+# Install only production dependencies
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# Copy application source (no tests or env files)
+COPY index.js ./
+
+EXPOSE 5000
+CMD ["node", "index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,22 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  backend-prod:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.prod
+    ports:
+      - "5000:5000"
+    environment:
+      NODE_ENV: production
+      PORT: 5000
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   frontend-prod:
     build:
       context: ./frontend
@@ -48,7 +64,7 @@ services:
     ports:
       - "3000:80"
     depends_on:
-      - backend
+      - backend-prod
     restart: unless-stopped
     logging:
       driver: json-file


### PR DESCRIPTION
## Summary
- create optimized `backend/Dockerfile.prod` for production builds
- add `backend-prod` service using that Dockerfile
- update `frontend-prod` to depend on `backend-prod`
- document dev vs. prod start commands in README

## Testing
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f8167a70832aa28f24cd2bfaa729