### PR TITLE
Add Vite install step to frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,9 @@ COPY package.json package-lock.json ./
 # Installiere exakt definierte Abhängigkeiten
 RUN npm ci
 
+# Ensure Vite is installed and cached in the image
+RUN npx vite --version
+
 # Restlichen Code kopieren
 COPY . .
 


### PR DESCRIPTION
## Summary
- ensure Vite is downloaded during the Docker build

## Testing
- `docker compose -f docker-compose.dev.yml up -d --build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68433e4e7024832aa2a0ad5d90602c6a