### PR TITLE
Add dev Dockerfile for frontend

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,10 +23,9 @@ services:
   frontend:
     build:
       context: ./frontend
+      dockerfile: Dockerfile.dev
     ports:
       - "${FRONTEND_DEV_PORT:-3000}:3000"
-    volumes:
-      - ./frontend:/app
     env_file:
       - ./frontend/.env
     environment:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,19 @@
+FROM node:18
+
+WORKDIR /app
+
+# Copy package definitions
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm install
+
+# Cache Vite install
+RUN npx vite --version
+
+# Copy remaining source
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Summary
- create Dockerfile.dev installing dependencies for vite runtime
- use Dockerfile.dev in docker-compose.dev.yml and drop frontend volume

## Testing
- `docker compose version` *(fails: command not found)*
- `docker compose -f docker-compose.dev.yml build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684342256828832a80d9eb5da0185115