### PR TITLE
Handle missing @trmnl/ui

### DIFF
--- a/frontend/src/pages/IndexPage.jsx
+++ b/frontend/src/pages/IndexPage.jsx
@@ -1,7 +1,35 @@
-import React from 'react'
-import { Layout, Text } from '@trmnl/ui'
+import React, { useEffect, useState } from 'react'
+
+let Layout
+let Text
+
+async function loadTRMNLUI(setError) {
+  try {
+    const mod = await import('@trmnl/ui')
+    Layout = mod.Layout
+    Text = mod.Text
+  } catch (err) {
+    console.error('Failed to load @trmnl/ui:', err)
+    setError(true)
+  }
+}
 
 function IndexPage() {
+  const [error, setError] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    loadTRMNLUI(setError).then(() => setLoaded(true))
+  }, [])
+
+  if (error) {
+    return <div>TRMNL UI not installed yet</div>
+  }
+
+  if (!loaded) {
+    return null
+  }
+
   return (
     <Layout>
       <Text>Hello TRMNL!</Text>


### PR DESCRIPTION
## Summary
- dynamically import `@trmnl/ui` components in IndexPage
- show a fallback message if the library is unavailable

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68434bb9daf4832a80f66b9825b4e1b6